### PR TITLE
Make buffer type writable

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -78,6 +78,17 @@ const buffer = (size) => StructType({
     opts.offset += length
     return result
   },
+  write (opts, value) {
+    if (!Buffer.isBuffer(value)) {
+      const valueType = Object.prototype.toString.call(null).replace(/^\[object (.+)\]$/, '$1')
+      throw new Error('cannot write value of incorrect type, expected Buffer, got ' + valueType)
+    }
+    const fieldLength = getValue(opts.struct, size)
+    const valueLength = Math.min(value.length, fieldLength)
+    value.copy(opts.buf, opts.offset, 0, valueLength)
+    opts.buf.fill(0, opts.offset + valueLength, opts.offset + fieldLength)
+    opts.offset += fieldLength
+  },
   size: (struct) => getValue(struct, size)
 })
 

--- a/test/StructType.js
+++ b/test/StructType.js
@@ -229,6 +229,27 @@ describe('Default types', function () {
       assert.deepEqual(buf, Buffer([ 0x00, 0x00, 0x00, 0x00 ]))
       assert.deepEqual(copy.buffer, Buffer([ 0x00, 0x01, 0x00, 0x02 ]))
     })
+
+    describe('writes buffers', function () {
+      var initialBuffer = Buffer([ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 ])
+      var buffer5bytes = buffer(5)
+
+      it('writes from buffers of the same length', function () {
+        var opts = { offset: 2, buf: Buffer(initialBuffer) }
+        buffer5bytes.write(opts, Buffer([ 0xF3, 0xF4, 0xF5, 0xF6, 0xF7 ]))
+        assert.deepEqual(opts.buf, Buffer([ 0x01, 0x02, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0x08, 0x09 ]))
+      })
+      it('writes from buffers longer than needed', function () {
+        var opts = { offset: 2, buf: Buffer(initialBuffer) }
+        buffer5bytes.write(opts, Buffer([ 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9 ]))
+        assert.deepEqual(opts.buf, Buffer([ 0x01, 0x02, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0x08, 0x09 ]))
+      })
+      it('writes from buffers shorter than needed and zero-fills the rest', function () {
+        var opts = { offset: 2, buf: Buffer(initialBuffer) }
+        buffer5bytes.write(opts, Buffer([ 0xF3, 0xF4, 0xF5 ]))
+        assert.deepEqual(opts.buf, Buffer([ 0x01, 0x02, 0xF3, 0xF4, 0xF5, 0x00, 0x00, 0x08, 0x09 ]))
+      })
+    })
   })
 
   describe('arrays', function () {


### PR DESCRIPTION
Usecase: 

This would make reading the structure, updating a few values from it and putting it back together easier when you don't care about the lenghty segment in the middle of it. For instance 36-bytes length `bV5Endpoints` field from [`BITMAPV5HEADER`](https://msdn.microsoft.com/en-us/library/dd183381(v=vs.85).aspx).