### PR TITLE
array definition syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "6"
-  - "7"
+  - 8
+  - 7
+  - 6
+  - 4

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ But if it is nonzero, `struct(buffer)` will return an object of this shape:
 Instances of `Struct()` can be called directly to read data from buffers. The first parameter is the
 Buffer you want to use. The second (optional) parameter is a parent object for the struct, as shown in [Value Paths](#valuepaths).
 
+#### struct.decode(buffer)
+
+`abstract-encoding` compatible.
+
+#### struct.encode(value[, buffer]\[, start = 0])
+
+Encode `value` into a `buffer`. Start writing at offset `start`. If no `buffer` is given, awestruct allocates one.
+`abstract-encoding` compatible.
+
+#### struct.encodingLength(value)
+
+Return the size in bytes that would be necessary to encode `value`.
+`abstract-encoding` compatible.
+
 ### Custom types: Struct.Type(type)
 
 Creates a Struct type object. `type` is an object:

--- a/README.md
+++ b/README.md
@@ -1,31 +1,35 @@
-awestruct
----------
+# awestruct
 
-Library for reading binary Buffer structures into objects in Node.js
+Library for reading complex binary Buffer structures into objects in Node.js
 
 [![NPM](https://nodei.co/npm/awestruct.png?compact=true)](https://nodei.co/npm/awestruct)
 
 ## Usage Example
 
-```javascript
-import Struct, { types as t } from 'awestruct'
+```js
+const Struct = require('awestruct')
+const t = Struct.types
+
 // https://github.com/goto-bus-stop/genie-slp/
-const slpHeader = Struct({
-  version: t.string(4)
-, numFrames: t.int32
-, comment: t.string(24)
+const slpHeader = Struct([
+  ['version', t.string(4)],
+  ['numFrames', t.int32],
+  ['comment', t.string(24)],
 
-, frames: t.array('numFrames', Struct({
-    cmdTableOffset: t.uint32
-  , outlineTableOffset: t.uint32
-  , paletteOffset: t.uint32
-  , properties: t.uint32
+  ['frames', t.array('numFrames', Struct([
+    ['cmdTableOffset', t.uint32],
+    ['outlineTableOffset', t.uint32],
+    ['paletteOffset', t.uint32],
+    ['properties', t.uint32],
 
-  , width: t.int32
-  , height: t.int32
-  , hotspot: Struct({ x: t.int32, y: t.int32 })
-  }))
-})
+    ['width', t.int32],
+    ['height', t.int32],
+    ['hotspot', Struct([
+      ['x', t.int32],
+      ['y', t.int32]
+    ])]
+  ]))]
+])
 
 const headerContents = slpHeader(slpBuffer) // → { version: '1.00', ... }
 ```
@@ -38,31 +42,47 @@ Creates a new `Struct` function that reads from `Buffer`s according to the descr
 
 `descriptor` is a Struct Descriptor. For example:
 
-```javascript
-var buffer = Buffer([ 0x10, 0x20, 0x30 ])
-  , t = Struct.types
-  , struct = Struct({
-      a: t.uint16
-    , b: t.uint8
-    })
+```js
+var buffer = Buffer.from([ 0x10, 0x20, 0x30 ])
+var t = Struct.types
+var struct = Struct([
+  ['a', t.uint16],
+  ['b', t.uint8]
+])
 
 struct(buffer) //→ { a: 8208, b: 48 }
 ```
 
-#### Struct#field(name, type)
+A struct descriptor is an array of fields. A field can either be an array with two elements, `[name, type]`, or an unnamed raw `type`.
+Unnamed types are useful if there is some padding you need to skip.
 
-Adds a field to the `Struct`. Useful if your code isn't going to always run on V8 (or other engines that accidentally keep object keys mostly in order of definition), or if you want to change the structure after the first instantiation.
+If an unnamed type reads another struct, it is merged into the current one. For example:
 
-Note that this *mutates* the current Struct, and does not create a new copy.
+```js
+var struct = Struct([
+  ['needToReadThing', t.int8],
+  t.skip(3), // padding
+  t.if('needToReadThing', Struct([
+    ['value1', t.int8],
+    ['value2', t.int8],
+  ]))
+])
+```
 
-```javascript
-var buffer = Buffer([ 0x10, 0x20, 0x30 ])
-  , t = Struct.types
-  , struct = Struct()
-    .field('a', t.uint16)
-    .field('b', t.uint8)
+Now, if the `buffer`'s first byte is zero, `struct(buffer)` will return an object like:
 
-struct(buffer) //→ { a: 8208, b: 48 }, same as above!
+```js
+{ needToReadThing: 0 }
+```
+
+But if it is nonzero, `struct(buffer)` will return an object of this shape:
+
+```js
+{
+  needToReadThing: 1,
+  value1: 43,
+  value2: 76
+}
 ```
 
 #### struct(buffer, ?parent)
@@ -73,7 +93,8 @@ Buffer you want to use. The second (optional) parameter is a parent object for t
 ### Custom types: Struct.Type(type)
 
 Creates a Struct type object. `type` is an object:
-```javascript
+
+```js
 var myType = Struct.Type({
   read: function (opts, parent) {
     // `opts.buf` is the Buffer to read from.
@@ -83,33 +104,34 @@ var myType = Struct.Type({
     var val = opts.buf.readInt8(opts.offset)
     opts.offset++
     return val * 1000
-  }
-, size: function (val, struct) {
+  },
+  size: function (val, struct) {
     return 1 // always 1 byte, could also write as { size: 1 }
   }
 })
 ```
 
 Custom types can be used like so:
-```javascript
-var myStruct = Struct({
-  builtinType: Struct.types.uint8
-, customType: myType
-})
-myStruct(Buffer([ 5, 5 ])) //→ { builtinType: 5, customType: 5000 }
+
+```js
+var myStruct = Struct([
+  ['builtinType', Struct.types.uint8],
+  ['customType', myType]
+])
+myStruct(Buffer.from([ 5, 5 ])) //→ { builtinType: 5, customType: 5000 }
 ```
 
-#### Struct.Type#transform(function)
+#### Struct.Type#mapRead(function)
 
 Creates a new type that applies the given transform function when reading values.
 
-```javascript
+```js
 var int32 = Struct.types.int32
-var myStruct = Struct({
-  a: int32
-, b: int32.transform(num => num * 2)
-})
-myStruct(Buffer([ 5, 5 ])) //→ { a: 5, b: 10 }
+var myStruct = Struct([
+  ['a', int32],
+  ['b', int32.mapRead(num => num * 2)]
+])
+myStruct(Buffer.from([ 5, 5 ])) //→ { a: 5, b: 10 }
 ```
 
 ### Builtin Types
@@ -132,47 +154,56 @@ These just map straight to the relevant `Buffer().read*()` methods. Number types
 
 The `n` parameter in each of those is a Value Path.
 
+#### Conditional types
+
+* `if(condition, type)` → Creates a type that decodes `type` if the `condition` Value Path is truthy.
+  `if()` types also have an `.else(type)` method, to specify a `type` to decode if the `condition` is falsy.
+
+  ```js
+  t.if('is32bit', t.int32).else(t.int16)
+  ```
+
 ### Value Paths
 
-Value paths are used to pass values to some type readers. Value paths can just be numbers, or depend on other values in the struct.
+Value paths are used to pass values to some type readers, particularly lengths. Value paths can be raw numbers, or depend on other values in the struct.
 
 Value paths take three forms:
 
-* Numbers: nothing fancy, produces the given number.
+* Numbers: produces the given number.
 * Strings: looks up the value at the given path.
 * Functions: takes the return value of the function.
 
-```javascript
-Struct({
-  len: int8
-, string: string('len')
-})(Buffer([ 3, 104, 105, 33 ])) → { len: 3, string: 'hi!' }
+```js
+Struct([
+  ['len', int8],
+  ['string', string('len')]
+])(Buffer.from([ 3, 104, 105, 33 ])) → { len: 3, string: 'hi!' }
 ```
 
-A string path can be just a plain property name, or a bunch of property names separated by dots ('child.struct.key') to descend into child structs, and can also start with '../' to look back into a "parent" struct.
+A string path can be a plain property name, or a bunch of property names separated by dots ('child.struct.key') to descend into child structs, and can also start with '../' to look back into a "parent" struct.
 
-```javascript
-Struct({
-  otherArrayLength: t.int8
-, subStruct: Struct({
-    irrelevantDataLength: t.int32
-  , array: t.array('../otherArrayLength', t.int8)
-  })
-, irrelevant: t.skip('subStruct.irrelevantDataLength')
-})
+```js
+Struct([
+  ['otherArrayLength', t.int8],
+  ['subStruct', Struct([
+    ['irrelevantDataLength', t.int32],
+    ['array', t.array('../otherArrayLength', t.int8)]
+  ])]
+  t.skip('subStruct.irrelevantDataLength')
+])
 ```
 
 Functions will be called with the current (possibly incomplete) struct in the first parameter:
 
-```javascript
-Struct({
-  child: Struct({
-    data: t.array(100, t.uint8)
-  , whatever: t.if((struct) => {
+```js
+Struct([
+  ['child', Struct([
+    ['data', t.array(100, t.uint8)],
+    ['whatever', t.if((struct) => {
       struct.data //→ array of 100 uint8s
       struct.$parent //→ the "parent" struct, like '../' in a path
       return true
-    }, uint8)
-  })
-})
+    }, uint8)]
+  ])]
+])
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "lib/Struct",
   "repository": "goto-bus-stop/awestruct",
   "dependencies": {
+    "dlv": "^1.1.0",
     "safe-buffer": "^5.0.1",
     "varstruct-match": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "repository": "goto-bus-stop/awestruct",
   "dependencies": {
     "dlv": "^1.1.0",
-    "safe-buffer": "^5.0.1",
-    "varstruct-match": "^3.1.0"
+    "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
     "babel-preset-stage-2": "^6.3.13",
     "buble": "^0.16.0",
     "mocha": "^4.0.0",
-    "standard": "^10.0.0"
+    "standard": "^10.0.0",
+    "varstruct-match": "^3.1.0"
   },
   "scripts": {
     "build": "buble src -o lib",

--- a/package.json
+++ b/package.json
@@ -11,24 +11,18 @@
   "author": "goto-bus-stop <rene@kooi.me>",
   "main": "lib/Struct",
   "repository": "goto-bus-stop/awestruct",
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
   "dependencies": {
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
+    "buble": "^0.16.0",
     "mocha": "^4.0.0",
     "standard": "^10.0.0"
   },
   "scripts": {
-    "build": "babel --presets es2015,stage-2 --out-dir lib src",
-    "test": "mocha && standard src/**/*.js test/**/*.js",
+    "build": "buble src -o lib",
+    "test": "mocha -r buble/register && standard src/**/*.js test/**/*.js",
     "prepublish": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "lib/Struct",
   "repository": "goto-bus-stop/awestruct",
   "dependencies": {
-    "safe-buffer": "^5.0.1"
+    "safe-buffer": "^5.0.1",
+    "varstruct-match": "^3.1.0"
   },
   "devDependencies": {
     "babel-preset-stage-2": "^6.3.13",

--- a/src/Struct.js
+++ b/src/Struct.js
@@ -81,31 +81,37 @@ function Struct (descriptor) {
    * Encodes an object into a Buffer as described by this Struct.
    * @param {Object} struct The Object to encode.
    */
-  const encode = (struct) => {
+  const encode = (struct, buffer) => {
     if (typeof struct !== 'object') {
       throw new TypeError('Expected an object')
     }
+
     const size = type.size(struct)
-    const buf = Buffer.alloc(size)
     const opts = {
-      buf,
+      struct,
+      buf: buffer || Buffer.alloc(size),
       offset: 0
     }
 
     type.write(opts, struct)
 
-    return buf
+    return opts.buf
   }
 
   const type = StructType({
     read: decode,
     write (opts, struct) {
-      fields.forEach(([ name, type ]) => {
-        if (name) {
-          type.write(opts, struct[name])
+      fields.forEach((field) => {
+        let name = null
+        let type = null
+        if (Array.isArray(field)) {
+          [name, type] = field
         } else {
-          type.write(opts, struct)
+          type = field
         }
+
+        const value = name ? struct[name] : struct
+        type.write(opts, value)
       })
     },
     size (struct) {

--- a/src/StructType.js
+++ b/src/StructType.js
@@ -62,15 +62,21 @@ function StructType (descr, mapRead = [], mapWrite = []) {
   return type
 
   function encode (value, buffer, offset) {
+    if (!offset) {
+      offset = 0
+    }
     if (!buffer) {
       buffer = Buffer.alloc(type.size(value))
     }
     const opts = { buf: buffer, offset: offset }
-    const result = type.write(opts, value)
+    type.write(opts, value)
     encode.bytes = opts.offset - offset
-    return result
+    return opts.buf
   }
   function decode (buffer, start, end) {
+    if (!start) {
+      start = 0
+    }
     const opts = { buf: buffer, offset: start }
     const value = type.read(opts)
     decode.bytes = opts.offset - start

--- a/src/StructType.js
+++ b/src/StructType.js
@@ -3,11 +3,12 @@ const { Buffer } = require('safe-buffer')
 module.exports = StructType
 
 function StructType (descr, mapRead = [], mapWrite = []) {
-  const type = (buf, ...rest) =>
-    type.read(
+  const type = function read (buf, ...rest) {
+    return type.read(
       Buffer.isBuffer(buf) ? { buf: buf, offset: 0 } : buf,
       ...rest
     )
+  }
 
   Object.keys(descr).forEach((key) => {
     type[key] = descr[key]

--- a/src/StructType.js
+++ b/src/StructType.js
@@ -1,4 +1,4 @@
-import { Buffer } from 'safe-buffer'
+const { Buffer } = require('safe-buffer')
 
 module.exports = StructType
 
@@ -54,5 +54,26 @@ function StructType (descr, mapRead = [], mapWrite = []) {
     type.size = () => descr.size
   }
 
+  // abstract-encoding
+  type.encode = encode
+  type.decode = decode
+  type.encodingLength = type.size
+
   return type
+
+  function encode (value, buffer, offset) {
+    if (!buffer) {
+      buffer = Buffer.alloc(type.size(value))
+    }
+    const opts = { buf: buffer, offset: offset }
+    const result = type.write(opts, value)
+    encode.bytes = opts.offset - offset
+    return result
+  }
+  function decode (buffer, start, end) {
+    const opts = { buf: buffer, offset: start }
+    const value = type.read(opts)
+    decode.bytes = opts.offset - start
+    return value
+  }
 }

--- a/src/StructType.js
+++ b/src/StructType.js
@@ -15,7 +15,7 @@ function StructType (descr, mapRead = [], mapWrite = []) {
 
   type.$structType = true
 
-  type.read = (...args) => {
+  type.read = function read (...args) {
     let val = descr.read.apply(type, args)
     for (let i = 0, l = mapRead.length; i < l; i++) {
       val = mapRead[i].call(type, val)
@@ -24,11 +24,11 @@ function StructType (descr, mapRead = [], mapWrite = []) {
   }
 
   if (type.write == null) {
-    type.write = () => {
+    type.write = function write () {
       throw new Error('unimplemented')
     }
   } else {
-    type.write = (opts, originalVal) => {
+    type.write = function write (opts, originalVal) {
       let val = originalVal
       for (let i = mapWrite.length - 1; i >= 0; i--) {
         val = mapWrite[i].call(type, val, opts)

--- a/src/getValue.js
+++ b/src/getValue.js
@@ -1,14 +1,4 @@
-/**
- * @param {Object} struct
- * @param {string} key
- * @return {*} Value.
- */
-function descend (struct, key) {
-  if (key.indexOf('.') === -1) {
-    return struct[key]
-  }
-  return key.split('.').reduce((struct, sub) => struct[sub], struct)
-}
+var dlv = require('dlv')
 
 /**
  * @param {Object} struct Object to find a value on.
@@ -26,7 +16,7 @@ module.exports = function getValue (struct, value) {
       struct = struct.$parent
       value = value.substr(3)
     }
-    return descend(struct, value)
+    return dlv(struct, value)
   } else if (typeof value === 'function') {
     return value.call(struct, struct)
   }

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
-import { Buffer } from 'safe-buffer'
-import StructType from './StructType'
-import getValue from './getValue'
+const { Buffer } = require('safe-buffer')
+const StructType = require('./StructType')
+const getValue = require('./getValue')
 
 /**
  * @param {string|Object|function} type Type name to find, or a StructType-ish descriptor object.
@@ -169,9 +169,15 @@ const when = (condition, type) => {
 }
 
 const skip = (size) => StructType({
-  read (opts) { opts.offset += size },
-  write (opts) { opts.offset += size },
-  size
+  read (opts, struct) {
+    opts.offset += getValue(struct, size)
+  },
+  write (opts, struct) {
+    opts.offset += getValue(struct, size)
+  },
+  size (struct) {
+    return getValue(struct, size)
+  }
 })
 
 const types = {

--- a/test/StructType.js
+++ b/test/StructType.js
@@ -1,6 +1,6 @@
 /* global it describe beforeEach */
 
-var Struct = require('../lib/Struct')
+var Struct = require('../src/Struct')
 var assert = require('assert')
 var Buffer = require('safe-buffer').Buffer
 


### PR DESCRIPTION
switch definition syntax to arrays instead of objects and `.field()`. array elements can be an array `[name, type]` or only a `type`. this way you don't have to name padding bytes anymore. substructs are merged into the parent if they are unnamed so an `if()` type can apply to multiple fields easily.