### PR TITLE
Add object path to error message if reading fails

### DIFF
--- a/test/StructType.js
+++ b/test/StructType.js
@@ -112,6 +112,24 @@ describe('Reading data', function () {
       array: [ { array: [ 2 ] } ]
     })
   })
+
+  it('throws a helpful message when a key cannot be read', function () {
+    var struct = Struct([
+      ['nesting', Struct([
+        ['a', int8],
+        ['b', Struct([
+          ['fails', array(1000, int8)]
+        ])]
+      ])]
+    ])
+
+    assert.throws(
+      function () {
+        struct(Buffer.from([ 1, 2, 3, 4, 5, 6 ]))
+      },
+      /Error reading 'nesting.b.fails'/
+    )
+  })
 })
 
 describe('Value paths', function () {


### PR DESCRIPTION
Currently, it can be really hard to figure out where reading failed—you get an error from deep inside `Struct.types.int32`, for example, but if there's hundreds of int32s in  your structure that doesn't really help.
This patch adds the path of the thing that could not be read to the error message. Performance seems to be barely affected.