### PR TITLE
Reduce some indirection

### DIFF
--- a/src/StructType.js
+++ b/src/StructType.js
@@ -15,20 +15,22 @@ function StructType (descr, mapRead = [], mapWrite = []) {
 
   type.$structType = true
 
-  const readImpl = descr.read.bind(type)
-  type.read = function read (opts, parent) {
-    let val = readImpl(opts, parent)
-    for (let i = 0, l = mapRead.length; i < l; i++) {
-      val = mapRead[i].call(type, val)
+  if (mapRead.length > 0) {
+    const readImpl = descr.read.bind(type)
+    type.read = function read (opts, parent) {
+      let val = readImpl(opts, parent)
+      for (let i = 0, l = mapRead.length; i < l; i++) {
+        val = mapRead[i].call(type, val)
+      }
+      return val
     }
-    return val
   }
 
   if (type.write == null) {
     type.write = function write () {
       throw new Error('unimplemented')
     }
-  } else {
+  } else if (mapWrite.length > 0) {
     const writeImpl = descr.write.bind(type)
     type.write = function write (opts, originalVal) {
       let val = originalVal

--- a/src/types.js
+++ b/src/types.js
@@ -47,15 +47,17 @@ function getType (type) {
  * @param {string} writeName Name of the writing method.
  */
 const makeBufferType = (size, readName, writeName) => StructType({
-  read (opts) {
-    const result = opts.buf[readName](opts.offset)
-    opts.offset += size
+  // eslint-disable-next-line no-new-func
+  read: Function('opts', `
+    var result = opts.buf.${readName}(opts.offset)
+    opts.offset += ${size}
     return result
-  },
-  write (opts, value) {
-    opts.buf[writeName](value, opts.offset)
-    opts.offset += size
-  },
+  `),
+  // eslint-disable-next-line no-new-func
+  write: Function('opts', 'value', `
+    opts.buf.${writeName}(value, opts.offset)
+    opts.offset += ${size}
+  `),
   size
 })
 


### PR DESCRIPTION
- remove unnecessary function wrapper if no mapping functions exist
- codegen for slightly faster native buffer functions

genie-dat tests go from ~13.5s to ~11.5s, about a 1s win for each optimisation.